### PR TITLE
Add afm-bb binary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ packages = ["src/bb"]
 
 [project.scripts]
 bb = "bb:cli"
+afm-bb = "bb:cli"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
Adds the BBC command as afm-bb too, which will make it accessible through the AFM CLI.